### PR TITLE
ENH: Added CLI support for new options

### DIFF
--- a/fmri_preproc.py
+++ b/fmri_preproc.py
@@ -56,7 +56,7 @@ def preproc_data() -> Literal[0]:
     # Preprocess data
 
     # Check arguments
-    if args.outdir and args.func and args.age:
+    if args.outdir and ((args.sub and args.run) or args.func):
 
         # Confirm phase-encoding directions
         if not args.sbref_pedir:
@@ -100,10 +100,15 @@ def preproc_data() -> Literal[0]:
                                                 group_map=None,
                                                 standard_res=None,
                                                 verbose=args.verbose,
-                                                log_level=args.log_level)
+                                                log_level=args.log_level,
+                                                smooth=args.smooth,
+                                                intnorm=args.intnorm)
         
         # Get subject info
         preproc: Pipeline = Pipeline(outdir=args.outdir, 
+                                     subid=args.subid,
+                                     sesid=args.sesid,
+                                     runid=args.runid,
                                      func=args.func, 
                                      scan_pma=args.age, 
                                      birth_ga=args.birth_age, 
@@ -157,10 +162,13 @@ def preproc_data() -> Literal[0]:
                               standard_res=settings_dict.get('standard_res'),
                               group_qc=settings_dict.get('group_qc'),
                               atlasdir=settings_dict.get('atlasdir'),
-                              preproc_only=settings_dict.get('preproc_only'))
+                              preproc_only=settings_dict.get('preproc_only'),
+                              smooth=settings_dict.get('smooth'),
+                              intnorm=settings_dict.get('intnorm'))
         elif args.method == 'run_all':
             # Import data
-            preproc.import_data(func_echospacing=args.func_echospacing,
+            preproc.import_data(func=args.func,
+                                func_echospacing=args.func_echospacing,
                                 func_pedir=args.func_pedir,
                                 T2w=args.T2w,
                                 T2w_brainmask=args.T2w_brainmask,
@@ -203,9 +211,11 @@ def preproc_data() -> Literal[0]:
                             standard_res=settings_dict.get('standard_res'),
                             group_qc=settings_dict.get('group_qc'),
                             atlasdir=settings_dict.get('atlasdir'),
-                            preproc_only=settings_dict.get('preproc_only'))
+                            preproc_only=settings_dict.get('preproc_only'),
+                            smooth=settings_dict.get('smooth'),
+                            intnorm=settings_dict.get('intnorm'))
     else:
-        print("\nREQUIRED: '--outdir', '--func', and '--age'.\n")
+        print("\nREQUIRED: '--outdir', '--sub', AND '--run'.\n")
         parser.print_help()
 
     return 0
@@ -215,9 +225,39 @@ def arg_parser() -> Tuple[argparse.ArgumentParser.parse_args, argparse.ArgumentP
     """Argument parser.
     """
     # Init parser
-    parser: argparse.ArgumentParser = argparse.ArgumentParser(description=__doc__)#, formatter_class=argparse.RawTextHelpFormatter)
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(description=__doc__,
+                                                              formatter_class=lambda prog: argparse.HelpFormatter(prog, max_help_position=55, width=100)
+                                                              #, formatter_class=argparse.RawTextHelpFormatter)
+                                                             )
 
     # Parse Arguments
+
+    reqoptions = parser.add_argument_group('Required Arguments')
+
+    reqoptions.add_argument('-s','--sub',
+                            dest="sub",
+                            type=str,
+                            metavar="<str>",
+                            default=None,
+                            help="REQUIRED: Subject ID.")
+    reqoptions.add_argument('-r','--run',
+                            dest="run",
+                            type=str,
+                            metavar="<str>",
+                            default=None,
+                            help="REQUIRED: Run number.")
+    reqoptions.add_argument('-o','--outdir',
+                            dest="ses",
+                            type=str,
+                            metavar="<str>",
+                            default=None,
+                            help="REQUIRED: Output parent directory.")
+    reqoptions.add_argument('-e','--ses',
+                            dest="ses",
+                            type=str,
+                            metavar="<str>",
+                            default=None,
+                            help="Session ID.")
 
     optoptions = parser.add_argument_group('Optional Arguments')
 
@@ -225,36 +265,42 @@ def arg_parser() -> Tuple[argparse.ArgumentParser.parse_args, argparse.ArgumentP
                             dest="version",
                             action="store_true",
                             help="Prints version, then exits.")
-    optoptions.add_argument('--write-config', '--write-settings',
+    optoptions.add_argument('--write-config',
                             type=str,
                             metavar="<file>",
                             dest="out_settings",
                             default=None,
                             help="Writes a template configuration (JSON) to file.")
+    
+    # Generic input options
+    optoptions.add_argument('-v','--verbose',
+                            dest="verbose",
+                            action="store_true",
+                            help="Enables verbose output to the command and log files.")
+    optoptions.add_argument('--log-level',
+                            type=str,
+                            metavar="<str>",
+                            dest="log_level",
+                            default='info',
+                            help="Log level to be written to output log files. Acceptable inputs include: 'info', 'debug', 'critical', 'warning', and 'error' [default='info'].")
+    optoptions.add_argument('--config', '--settings',
+                            type=str,
+                            metavar="<file>",
+                            dest="settings",
+                            default=DEFAULT_SETTINGS_FILE,
+                            help="Configuration (JSON) file that contains additional input arguments not specified at the command line.")
 
-    mainargparser = parser.add_subparsers(help="Data preprocessing pipeline sections for 'fmri_preproc'.")
-
-    # TODO: 
-    #   * Make 'outdir', 'func', 'age', 'birth_age' parent parser variables
-    #   * Add parent parser variables to all the subparsers
-    #   * Add subject and session IDs to parent parsers
-    #   * Add smoothing and intnorm options to command line parsers
+    mainargparser = parser.add_subparsers(title="subcommands",
+                                          description="Data preprocessing pipeline sections for 'fmri_preproc'.",
+                                          help="Type the 'subcommand' name followed by '-h' or '--help' for more information.")
 
     # IMPORT DATA ARGS
-    importoptions = mainargparser.add_parser('import-data', help="Imports the subject's imaging data into a working directory for image preprocessing.")
+    importoptions = mainargparser.add_parser('import-data', 
+                                             parents=[reqoptions],
+                                             formatter_class=lambda prog: argparse.HelpFormatter(prog, max_help_position=55, width=100),
+                                             add_help=False,
+                                             help="Imports the subject's imaging data into a working directory for image preprocessing.")
 
-    importoptions.add_argument('-o','--outdir',
-                               type=str,
-                               metavar="<path>",
-                               dest="outdir",
-                               default=None,
-                               help="REQUIRED: Output parent directory location for the working directory.")
-    importoptions.add_argument('-f','--func',
-                               type=str,
-                               metavar="<file>",
-                               dest="func",
-                               default=None,
-                               help="REQUIRED: Input rs-fMRI data. NOTE: Input data MUST conform to the BIDS naming convention (e.g. 'sub-001[_ses-001]_task-rest[_run-01]_bold.nii.gz').")
     importoptions.add_argument('-a','--age',
                                type=str,
                                metavar="<age>",
@@ -274,11 +320,11 @@ def arg_parser() -> Tuple[argparse.ArgumentParser.parse_args, argparse.ArgumentP
                                metavar="<file>",
                                dest="T2w",
                                default=None,
-                               help="Input (bias corrected, e.g. '_restore') T2w image data.")
+                               help="REQUIRED: Input (bias corrected, e.g. '_restore') T2w image data.")
     importoptions.add_argument('--T2w-brainmask',
                                type=str,
                                metavar="<file>",
-                               dest="T2w_brainmask",
+                               dest="REQUIRED: T2w_brainmask",
                                default=None,
                                help="Input T2w brainmask image data (_brainmask_bet).")
     importoptions.add_argument('--T2w-tissue-seg',
@@ -286,13 +332,13 @@ def arg_parser() -> Tuple[argparse.ArgumentParser.parse_args, argparse.ArgumentP
                                metavar="<file>",
                                dest="dseg",
                                default=None,
-                               help="Input Draw-EM neonatal brain tissue segmentation (e.g. '_drawem_tissue_labels') image data. NOTE: Other brain tissue files can be used (e.g. from FreeSurfer or FSL's FAST).")
+                               help="REQUIRED: Input Draw-EM or other neonatal brain tissue segmentation (e.g. '_drawem_tissue_labels') image data. NOTE: Other brain tissue files can be used (e.g. from FreeSurfer or FSL's FAST).")
     importoptions.add_argument('--tissue-seg-type',
                                type=str,
                                metavar="<str>",
                                dest="dseg_type",
                                default=None,
-                               help="Input brain tissue segmentation type. Acceptable inputs include: 'drawem', 'freesurfer_aseg', or 'fsl_fast'.")
+                               help="REQUIRED: Input brain tissue segmentation type. Acceptable inputs include: 'drawem', 'freesurfer_aseg', or 'fsl_fast'.")
     importoptions.add_argument('--T1w',
                                type=str,
                                metavar="<file>",
@@ -301,18 +347,24 @@ def arg_parser() -> Tuple[argparse.ArgumentParser.parse_args, argparse.ArgumentP
                                help="Input (bias corrected, e.g. '_restore') T1w image data.")
     
     # Functional import data
+    importoptions.add_argument('-f','--func',
+                               type=str,
+                               metavar="<file>",
+                               dest="func",
+                               default=None,
+                               help="REQUIRED: Input rs-fMRI data. NOTE: IF input data conforms to the BIDS naming convention (e.g. 'sub-001[_ses-001]_task-rest[_run-01]_bold.nii.gz'), then '--sub', '--ses', and '--run' need not be specified.")
     importoptions.add_argument('--func-echospacing',
                                type=float,
                                metavar="<float>",
                                dest="func_echospacing",
                                default=None,
-                               help="Functional echospacing.")
+                               help="REQUIRED: Functional echospacing.")
     importoptions.add_argument('--func-pedir',
                                type=str,
                                metavar="<PE-dir>",
                                dest="func_pedir",
                                default=None,
-                               help="Phase encoding direction. Acceptable inputs include: 'PA', 'AP', 'RL', 'LR', 'IS', or 'SI'.")
+                               help="REQUIRED: Phase encoding direction. Acceptable inputs include: 'PA', 'AP', 'RL', 'LR', 'IS', or 'SI'.")
     importoptions.add_argument('--func-slorder',
                                type=str,
                                metavar="<file>",
@@ -425,85 +477,26 @@ def arg_parser() -> Tuple[argparse.ArgumentParser.parse_args, argparse.ArgumentP
                                dest="si_dir",
                                default=None,
                                help="S -> I (superior to inferior) Spinecho MR image data.")
-    
-    # Generic input options
-    importoptions.add_argument('-v','--verbose',
-                            dest="verbose",
-                            action="store_true",
-                            help="Enables verbose output to the command and log files.")
-    importoptions.add_argument('--log-level',
-                            type=str,
-                            metavar="<str>",
-                            dest="log_level",
-                            default='info',
-                            help="Log level to be written to output log files. Acceptable inputs include: 'info', 'debug', 'critical', 'warning', and 'error' [default='info'].")
-    importoptions.add_argument('--config', '--settings',
-                            type=str,
-                            metavar="<file>",
-                            dest="settings",
-                            default=DEFAULT_SETTINGS_FILE,
-                            help="Configuration (JSON) file that contains additional input arguments not specified at the command line.")
 
     importoptions.set_defaults(method='import')
 
+    
     # PRE-MCDC ARGS
-    premcdcoptions = mainargparser.add_parser('pre-mcdc', help='Pre- Motion Correction and Distortion Correction.')
-
-    premcdcoptions.add_argument('-o','--outdir',
-                                type=str,
-                                metavar="<path>",
-                                dest="outdir",
-                                help="REQUIRED: Output parent directory location for the working directory.")
-    premcdcoptions.add_argument('-f','--func',
-                                type=str,
-                                metavar="<file>",
-                                dest="func",
-                                help="REQUIRED: Input rs-fMRI data. NOTE: Input data MUST conform to the BIDS naming convention (e.g. 'sub-001[_ses-001]_task-rest[_run-01]_bold.nii.gz').")
-    premcdcoptions.add_argument('-a','--age',
-                                type=str,
-                                metavar="<age>",
-                                dest="age",
-                                help="REQUIRED: Age at scan. Acceptable inputs include: 'neo', 28 - 44 (PMA, in wks), and 1 or 2 (yrs).")
-
-    # Generic input options
-    premcdcoptions.add_argument('-v','--verbose',
-                                dest="verbose",
-                                action="store_true",
-                                help="Enables verbose output to the command and log files.")
-    premcdcoptions.add_argument('--log-level',
-                                type=str,
-                                metavar="<str>",
-                                dest="log_level",
-                                default='info',
-                                help="Log level to be written to output log files. Acceptable inputs include: 'info', 'debug', 'critical', 'warning', and 'error' [default='info'].")
-    premcdcoptions.add_argument('--config', '--settings',
-                                type=str,
-                                metavar="<file>",
-                                dest="settings",
-                                default=DEFAULT_SETTINGS_FILE,
-                                help="Configuration (JSON) file that contains additional input arguments not specified at the command line.")
+    premcdcoptions = mainargparser.add_parser('pre-mcdc', 
+                                              parents=[reqoptions],
+                                              formatter_class=lambda prog: argparse.HelpFormatter(prog, max_help_position=55, width=100),
+                                              add_help=False,
+                                              help="Pre-Motion Correction and Distortion Correction (MCDC).")
 
     premcdcoptions.set_defaults(method='pre_mcdc')
 
     # MCDC ARGS
-    mcdcoptions = mainargparser.add_parser('mcdc', help='Motion Correction and Distortion Correction.')
-
-    mcdcoptions.add_argument('-o','--outdir',
-                             type=str,
-                             metavar="<path>",
-                             dest="outdir",
-                             help="REQUIRED: Output parent directory location for the working directory.")
-    mcdcoptions.add_argument('-f','--func',
-                             type=str,
-                             metavar="<file>",
-                             dest="func",
-                             help="REQUIRED: Input rs-fMRI data. NOTE: Input data MUST conform to the BIDS naming convention (e.g. 'sub-001[_ses-001]_task-rest[_run-01]_bold.nii.gz').")
-    mcdcoptions.add_argument('-a','--age',
-                             type=str,
-                             metavar="<age>",
-                             dest="age",
-                             help="REQUIRED: Age at scan. Acceptable inputs include: 'neo', 28 - 44 (PMA, in wks), and 1 or 2 (yrs).")
-
+    mcdcoptions = mainargparser.add_parser('mcdc', 
+                                           parents=[reqoptions],
+                                           formatter_class=lambda prog: argparse.HelpFormatter(prog, max_help_position=55, width=100),
+                                           add_help=False,
+                                           help="Motion Correction and Distortion Correction (MCDC).")
+    
     # Slice-to-volume args
     mcdcoptions.add_argument('--s2v', '--slice-to-volume',
                              dest="s2v",
@@ -526,44 +519,14 @@ def arg_parser() -> Tuple[argparse.ArgumentParser.parse_args, argparse.ArgumentP
                              default=None,
                              help="Enables FSL's MCFLIRT-based motion correction. NOTE: Enabling this option DISABLES: '--s2v', '--dc', and '--mbs' options.")
 
-    # Generic input options
-    mcdcoptions.add_argument('-v','--verbose',
-                             dest="verbose",
-                             action="store_true",
-                             help="Enables verbose output to the command and log files.")
-    mcdcoptions.add_argument('--log-level',
-                             type=str,
-                             metavar="<str>",
-                             dest="log_level",
-                             default='info',
-                             help="Log level to be written to output log files. Acceptable inputs include: 'info', 'debug', 'critical', 'warning', and 'error' [default='info'].")
-    mcdcoptions.add_argument('--config', '--settings',
-                             type=str,
-                             metavar="<file>",
-                             dest="settings",
-                             default=DEFAULT_SETTINGS_FILE,
-                             help="Configuration (JSON) file that contains additional input arguments not specified at the command line.")
-
     mcdcoptions.set_defaults(method='mcdc')
 
     # POST-MCDC
-    postmcdcoptions = mainargparser.add_parser('post-mcdc', help='Post-MCDC preprocessing, which includes: func -> template registration, ICA-based denoising, and QC (web page).')
-
-    postmcdcoptions.add_argument('-o','--outdir',
-                                 type=str,
-                                 metavar="<path>",
-                                 dest="outdir",
-                                 help="REQUIRED: Output parent directory location for the working directory.")
-    postmcdcoptions.add_argument('-f','--func',
-                                 type=str,
-                                 metavar="<file>",
-                                 dest="func",
-                                 help="REQUIRED: Input rs-fMRI data. NOTE: Input data MUST conform to the BIDS naming convention (e.g. 'sub-001[_ses-001]_task-rest[_run-01]_bold.nii.gz').")
-    postmcdcoptions.add_argument('-a','--age',
-                                 type=str,
-                                 metavar="<age>",
-                                 dest="age",
-                                 help="REQUIRED: Age at scan. Acceptable inputs include: 'neo', 28 - 44 (PMA, in wks), and 1 or 2 (yrs).")
+    postmcdcoptions = mainargparser.add_parser('post-mcdc', 
+                                               parents=[reqoptions],
+                                               formatter_class=lambda prog: argparse.HelpFormatter(prog, max_help_position=55, width=100),
+                                               add_help=False,
+                                               help="Post-MCDC preprocessing, which includes: func -> template registration, ICA-based denoising, and QC (web page).")
 
     # Registration args
     postmcdcoptions.add_argument('--standard-age',
@@ -605,7 +568,7 @@ def arg_parser() -> Tuple[argparse.ArgumentParser.parse_args, argparse.ArgumentP
                                  metavar="<str>",
                                  dest="rdata",
                                  default=None, # TODO: Set this later
-                                 help="Trained FIX classifier (stored as a Rdata file).")
+                                 help="Trained FIX classifier (Rdata file).")
     postmcdcoptions.add_argument('--fix-threshold',
                                  type=int,
                                  metavar="<int>",
@@ -613,202 +576,26 @@ def arg_parser() -> Tuple[argparse.ArgumentParser.parse_args, argparse.ArgumentP
                                  default=10,
                                  help="FIX noise classification threshold. [default=10].")
 
-    # Generic input options
-    postmcdcoptions.add_argument('-v','--verbose',
-                                 dest="verbose",
+    # POST-PROCESS
+    postmcdcoptions.add_argument('--smooth',
+                                 type=float,
+                                 metavar="<float>",
+                                 dest="smooth",
+                                 default=None,
+                                 help="Smoothing kernel (FWHM, in mm) [default=disabled].")
+    postmcdcoptions.add_argument('--int-nrom',
+                                 dest="intnorm",
                                  action="store_true",
-                                 help="Enables verbose output to the command and log files.")
-    postmcdcoptions.add_argument('--log-level',
-                                 type=str,
-                                 metavar="<str>",
-                                 dest="log_level",
-                                 default='info',
-                                 help="Log level to be written to output log files. Acceptable inputs include: 'info', 'debug', 'critical', 'warning', and 'error' [default='info'].")
-    postmcdcoptions.add_argument('--config', '--settings',
-                                 type=str,
-                                 metavar="<file>",
-                                 dest="settings",
-                                 default=DEFAULT_SETTINGS_FILE,
-                                 help="Configuration (JSON) file that contains additional input arguments not specified at the command line.")
+                                 help="Performs intensity normalization OR grand-mean scaling IF '--smooth' is specified and greater than 0 [default=disabled].")
 
     postmcdcoptions.set_defaults(method='post_mcdc')
 
-    runalloptions = mainargparser.add_parser('run-all', help='Run-all preprocessing steps of the pipeline.')
-
-    runalloptions.add_argument('-o','--outdir',
-                               type=str,
-                               metavar="<path>",
-                               dest="outdir",
-                               help="REQUIRED: Output parent directory location for the working directory.")
-    runalloptions.add_argument('-f','--func',
-                               type=str,
-                               metavar="<file>",
-                               dest="func",
-                               help="REQUIRED: Input rs-fMRI data. NOTE: Input data MUST conform to the BIDS naming convention (e.g. 'sub-001[_ses-001]_task-rest[_run-01]_bold.nii.gz').")
-    runalloptions.add_argument('-a','--age',
-                               type=str,
-                               metavar="<age>",
-                               dest="age",
-                               help="REQUIRED: Age at scan. Acceptable inputs include: 'neo', 28 - 44 (PMA, in wks), and 1 or 2 (yrs).")
-    runalloptions.add_argument('--birth-age',
-                               type=float,
-                               metavar="<age>",
-                               dest="birth_age",
-                               help="Gestational age at birth.")
-
-    # Structural import data
-    runalloptions.add_argument('--T2w',
-                               type=str,
-                               metavar="<file>",
-                               dest="T2w",
-                               help="Input (bias corrected, e.g. '_restore') T2w image data.")
-    runalloptions.add_argument('--T2w-brainmask',
-                               type=str,
-                               metavar="<file>",
-                               dest="T2w_brainmask",
-                               help="Input T2w brainmask image data (_brainmask_bet).")
-    runalloptions.add_argument('--T2w-tissue-seg',
-                               type=str,
-                               metavar="<file>",
-                               dest="dseg",
-                               help="Input Draw-EM neonatal brain tissue segmentation (e.g. '_drawem_tissue_labels') image data. NOTE: Other brain tissue files can be used (e.g. from FreeSurfer or FSL's FAST).")
-    runalloptions.add_argument('--tissue-seg-type',
-                               type=str,
-                               metavar="<str>",
-                               dest="dseg_type",
-                               help="Input brain tissue segmentation type. Acceptable inputs include: 'drawem', 'freesurfer_aseg', or 'fsl_fast'.")
-    runalloptions.add_argument('--T1w',
-                               type=str,
-                               metavar="<file>",
-                               dest="T1w",
-                               default=None,
-                               help="Input (bias corrected, e.g. '_restore') T1w image data.")
-    
-    # Functional import data
-    runalloptions.add_argument('--func-echospacing',
-                               type=float,
-                               metavar="<float>",
-                               dest="func_echospacing",
-                               default=None,
-                               help="Functional echospacing.")
-    runalloptions.add_argument('--func-pedir',
-                               type=str,
-                               metavar="<PE-dir>",
-                               dest="func_pedir",
-                               default=None,
-                               help="Phase encoding direction. Acceptable inputs include: 'PA', 'AP', 'RL', 'LR', 'IS', or 'SI'.")
-    runalloptions.add_argument('--func-slorder',
-                               type=str,
-                               metavar="<file>",
-                               dest="func_slorder",
-                               default=None,
-                               help="Functional slice order specification file. This file specifies the slice acquisition order of the input rs-fMRI. If not provided one can be created internally IF 'func-mbfactor' is specified.")
-    runalloptions.add_argument('--func-brainmask',
-                               type=str,
-                               metavar="<file>",
-                               dest="func_brainmask",
-                               default=None,
-                               help="Functional brain mask.")
-    runalloptions.add_argument('--func-inplane-accel',
-                               type=float,
-                               metavar="<float>",
-                               dest="func_inplane_accel",
-                               default=1.00,
-                               help="Functional inplane acceleration (e.g. SENSE factor on Philips MR scanners or GRAPPA, the general term) [default=1.00].")
-    runalloptions.add_argument('--func-mbfactor',
-                               type=int,
-                               metavar="<int>",
-                               dest="mb_factor",
-                               default=None,
-                               help="Functional multi-band factor.")
-    
-    # Single-band reference import data
-    runalloptions.add_argument('--sbref',
-                               type=str,
-                               metavar="<file>",
-                               dest="sbref",
-                               default=None,
-                               help="Single band reference MR image data.")
-    runalloptions.add_argument('--sbref-brainmask',
-                               type=str,
-                               metavar="<file>",
-                               dest="sbref_brainmask",
-                               default=None,
-                               help="Single band reference MR brain mask image data.")
-    runalloptions.add_argument('--sbref-echospacing',
-                               type=float,
-                               metavar="<float>",
-                               dest="sbref_echospacing",
-                               default=None,
-                               help="Single band reference MR image echospacing. If not specified, then it is assumed to match '--func-echospacing'.")
-    runalloptions.add_argument('--sbref-pedir',
-                               type=str,
-                               metavar="<PE-dir>",
-                               dest="sbref_pedir",
-                               default=None,
-                               help="Single band reference MR image data phase encoding direction. NOTE: This should match '--func-pedir'. If not specified, then it is assumed to match '--func-pedir'. If this is not case, this could result in mis-registration and distortion correction issues.")
-    
-    # Single-band reference import data
-    runalloptions.add_argument('--spinecho',
-                               type=str,
-                               metavar="<file>",
-                               dest="spinecho",
-                               default=None,
-                               help="Spinecho MR image data.")
-    runalloptions.add_argument('--sp-echospacing',
-                               type=float,
-                               metavar="<float>",
-                               dest="spinecho_echospacing",
-                               default=None,
-                               help="Spinecho MR image echospacing. If not specified, then it is assumed to match '--func-echospacing'.")
-    runalloptions.add_argument('--sp-pedir',
-                               type=str,
-                               metavar="<PE-dir,PE-dir,..,PE-dir>",
-                               dest="spinecho_pedir",
-                               default=None,
-                               help="Spinecho MR image phase encoding direction(s), specified as a comma separated list. Accepatable inputs are the same as those specifed for both '--func-pedir', and '--sbref-pedir'.")
-    runalloptions.add_argument('--sp-inplane-accel',
-                               type=float,
-                               metavar="<float>",
-                               dest="spinecho_inplaneacc",
-                               default=None,
-                               help="Spinecho MR image inplane acceleration . If not specified, then it is assumed to match '--func-inplane-accel'.")
-    runalloptions.add_argument('--sp-AP',
-                               type=str,
-                               metavar="<file>",
-                               dest="ap_dir",
-                               default=None,
-                               help="A -> P (anterior to posterior) Spinecho MR image data.")
-    runalloptions.add_argument('--sp-PA',
-                               type=str,
-                               metavar="<file>",
-                               dest="pa_dir",
-                               default=None,
-                               help="P -> A (posterior to anterior) Spinecho MR image data.")
-    runalloptions.add_argument('--sp-LR',
-                               type=str,
-                               metavar="<file>",
-                               dest="lr_dir",
-                               default=None,
-                               help="L -> R (left to right) Spinecho MR image data.")
-    runalloptions.add_argument('--sp-RL',
-                               type=str,
-                               metavar="<file>",
-                               dest="rl_dir",
-                               default=None,
-                               help="R -> L (right to left) Spinecho MR image data.")
-    runalloptions.add_argument('--sp-IS',
-                               type=str,
-                               metavar="<file>",
-                               dest="is_dir",
-                               default=None,
-                               help="I -> S (inferior to superior) Spinecho MR image data.")
-    runalloptions.add_argument('--sp-SI',
-                               type=str,
-                               metavar="<file>",
-                               dest="si_dir",
-                               default=None,
-                               help="S -> I (superior to inferior) Spinecho MR image data.")
+    # RUN ALL SECTIONS
+    runalloptions = mainargparser.add_parser('run-all', 
+                                             parents=[importoptions],
+                                             formatter_class=lambda prog: argparse.HelpFormatter(prog, max_help_position=55, width=100),
+                                             add_help=False,
+                                             help="Perform/Run all preprocessing steps of the pipeline.")
 
     # Slice-to-volume args
     runalloptions.add_argument('--s2v', '--slice-to-volume',
@@ -879,24 +666,18 @@ def arg_parser() -> Tuple[argparse.ArgumentParser.parse_args, argparse.ArgumentP
                                  dest="fix_threshold",
                                  default=10,
                                  help="FIX noise classification threshold. [default=10].")
-
-    # Generic input options
-    runalloptions.add_argument('-v','--verbose',
-                                 dest="verbose",
-                                 action="store_true",
-                                 help="Enables verbose output to the command and log files.")
-    runalloptions.add_argument('--log-level',
-                                 type=str,
-                                 metavar="<str>",
-                                 dest="log_level",
-                                 default='info',
-                                 help="Log level to be written to output log files. Acceptable inputs include: 'info', 'debug', 'critical', 'warning', and 'error' [default='info'].")
-    runalloptions.add_argument('--config', '--settings',
-                                 type=str,
-                                 metavar="<file>",
-                                 dest="settings",
-                                 default=DEFAULT_SETTINGS_FILE,
-                                 help="Configuration (JSON) file that contains additional input arguments not specified at the command line.")
+    
+    # POST-PROCESS
+    runalloptions.add_argument('--smooth',
+                               type=float,
+                               metavar="<float>",
+                               dest="smooth",
+                               default=None,
+                               help="Smoothing kernel (FWHM, in mm) [default=disabled].")
+    runalloptions.add_argument('--int-nrom',
+                               dest="intnorm",
+                               action="store_true",
+                               help="Performs intensity normalization OR grand-mean scaling IF '--smooth' is specified and greater than 0 [default=disabled].")
 
     runalloptions.set_defaults(method='run_all')
 


### PR DESCRIPTION
Added command line interface support for: `subid`, `sesid`, `runid`, `smooth`, and `intnorm`.
Additionally, the CLI argument parser was cleaned up to reduce bugs by organizing common
options under a parent argument parser. Pipeline sections and their corresponding options
were placed in child argument parsers, which also inherited parsed arguments from the
parent.